### PR TITLE
家族SNS投稿にコメント機能の追加

### DIFF
--- a/app/assets/javascripts/sns_comments.coffee
+++ b/app/assets/javascripts/sns_comments.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/sns_comments.scss
+++ b/app/assets/stylesheets/sns_comments.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the sns_comments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -65,8 +65,8 @@ class FamiliesController < ApplicationController
   def timeline
     my_family = current_family
     @family_post = my_family.family_posts.build
-    # @family_posts = my_family.family_posts.order(created_at: :desc).page(params[:page])
-    @family_posts = my_family.family_posts.page(params[:page])
+    @sns_comment = my_family.sns_comments.build(user_id: current_user.id, family_post_id: 1)
+    @family_posts = my_family.family_posts.order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/controllers/sns_comments_controller.rb
+++ b/app/controllers/sns_comments_controller.rb
@@ -1,0 +1,24 @@
+class SnsCommentsController < ApplicationController
+  def create
+    my_family = current_family
+    @sns_comment = my_family.sns_comments.build(sns_comment_params)
+    @sns_comment.user_id = current_user.id
+    if @sns_comment.save
+      flash[:success] = "投稿しました！"
+      redirect_to request.referrer || 'families/timeline'
+    else
+      flash[:error] = "投稿に失敗しました。改めて投稿し直してください。"
+    end
+  end
+
+  def destroy
+    @family_post = FamilyPost.find(params[:family_post_id])
+    current_family.delete_sns_comment(@family_post)
+  end
+
+  private
+  def sns_comment_params
+    params.require(:sns_comment).permit(:user_id, :family_id, :family_post_id, :content)
+  end
+
+end

--- a/app/helpers/sns_comments_helper.rb
+++ b/app/helpers/sns_comments_helper.rb
@@ -1,0 +1,2 @@
+module SnsCommentsHelper
+end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -48,4 +48,7 @@ class Family < ActiveRecord::Base
   def family_post_stared?(family_post)
     stared_family_posts.include?(family_post)
   end
+
+  has_many :sns_comments, class_name: SnsComment, foreign_key: 'family_id', dependent: :destroy
+  has_many :sns_commented_posts, through: :sns_comments, source: :family_post
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -51,4 +51,13 @@ class Family < ActiveRecord::Base
 
   has_many :sns_comments, class_name: SnsComment, foreign_key: 'family_id', dependent: :destroy
   has_many :sns_commented_posts, through: :sns_comments, source: :family_post
+
+  def sns_comment(family_post, content)
+    sns_comments.find_or_create_by(family_post_id: family_post.id, user_id: current_user.id, content: content)
+  end
+
+  def delete_sns_comment(family_post)
+    sns_comment = sns_comments.find_by(family_post_id: family_post.id, user_id: current_user.id)
+    sns_comment.destroy if sns_comment
+  end
 end

--- a/app/models/family_post.rb
+++ b/app/models/family_post.rb
@@ -7,4 +7,7 @@ class FamilyPost < ActiveRecord::Base
 
   has_many :family_post_stars, class_name: FamilyPostStar, foreign_key: 'family_post_id', dependent: :destroy
   has_many :family_post_families, through: :family_post_stars, source: :family
+
+  has_many :sns_comments, class_name: SnsComment, foreign_key: 'family_post_id', dependent: :destroy
+  has_many :sns_comments_families, through: :sns_comments, source: :family
 end

--- a/app/models/family_post.rb
+++ b/app/models/family_post.rb
@@ -10,4 +10,8 @@ class FamilyPost < ActiveRecord::Base
 
   has_many :sns_comments, class_name: SnsComment, foreign_key: 'family_post_id', dependent: :destroy
   has_many :sns_comments_families, through: :sns_comments, source: :family
+
+  def has_comment?
+    sns_comments_families.count != 0
+  end
 end

--- a/app/models/sns_comment.rb
+++ b/app/models/sns_comment.rb
@@ -1,0 +1,5 @@
+class SnsComment < ActiveRecord::Base
+  belongs_to :family
+  belongs_to :family_post
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,7 @@ class User < ActiveRecord::Base
   def has_family?
     family_id.present?
   end
+
+  has_many :sns_comments, class_name: SnsComment, foreign_key: 'user_id', dependent: :destroy
+  has_many :sns_commented_posts, through: :sns_comments, source: :family_post
 end

--- a/app/views/family_posts/_family_posts.html.erb
+++ b/app/views/family_posts/_family_posts.html.erb
@@ -25,9 +25,12 @@
     <div class="familyPostComment">
       <%= render 'shared/sns_comment_form', family_post: family_post %>
       <% if family_post.has_comment? %>
+          <div class="familyPostCommentsCount">
+              <p>コメント<%= family_post.sns_comments_families.count %>件</p>
+          </div>
           <div class="familyPostComments">
               <% family_post.sns_comments.each do |c| %>
-                <%= c.content %>
+                <div><%= c.content %></div>
               <% end %>
           </div>
       <% end %>

--- a/app/views/family_posts/_family_posts.html.erb
+++ b/app/views/family_posts/_family_posts.html.erb
@@ -21,6 +21,17 @@
       </div>
       <div id="familyPostStarCount-<%= family_post.id %>"><%= family_post.family_post_stars.count %></div>
     </div>
+
+    <div class="familyPostComment">
+      <%= render 'shared/sns_comment_form', family_post: family_post %>
+      <% if family_post.has_comment? %>
+          <div class="familyPostComments">
+              <% family_post.sns_comments.each do |c| %>
+                <%= c.content %>
+              <% end %>
+          </div>
+      <% end %>
+    </div>
   </div>
   <div class="familyPost-timestamp">
     Posted <%= time_ago_in_words(family_post.created_at) %> ago.

--- a/app/views/shared/_sns_comment_form.html.erb
+++ b/app/views/shared/_sns_comment_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_for(@sns_comment, url: family_post_sns_comments_path(family_post_id: family_post.id)) do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <div class="field">
+      <%= f.text_area :content, placeholder: "投稿するテキストを入力できます" %>
+    </div>
+    <div class="field">
+      <%= f.hidden_field :family_post_id, value: family_post.id %>
+    </div>
+    <%= f.submit "Comment", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/sns_comments/create.html.erb
+++ b/app/views/sns_comments/create.html.erb
@@ -1,0 +1,2 @@
+<h1>SnsComments#create</h1>
+<p>Find me in app/views/sns_comments/create.html.erb</p>

--- a/app/views/sns_comments/destroy.html.erb
+++ b/app/views/sns_comments/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>SnsComments#destroy</h1>
+<p>Find me in app/views/sns_comments/destroy.html.erb</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,6 @@ module Prototype
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Rails.application.routes.draw do
   end
 
   resources :family_relationships, only: [:create, :destroy]
-  resources :family_posts, only: [:create, :destroy]
+  resources :family_posts, only: [:create, :destroy] do
+    resources :sns_comments, only: [:create, :destroy]
+  end
   resources :family_post_stars, only: [:create, :destroy]
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/db/migrate/20161110160609_create_sns_comments.rb
+++ b/db/migrate/20161110160609_create_sns_comments.rb
@@ -1,0 +1,12 @@
+class CreateSnsComments < ActiveRecord::Migration
+  def change
+    create_table :sns_comments do |t|
+      t.references :family, index: true
+      t.references :family_post, index: true
+      t.references :user, index: true
+
+      t.timestamps null: false
+      t.index [:family_id, :family_post_id, :user_id]
+    end
+  end
+end

--- a/db/migrate/20161111010142_add_content_to_sns_comment.rb
+++ b/db/migrate/20161111010142_add_content_to_sns_comment.rb
@@ -1,0 +1,5 @@
+class AddContentToSnsComment < ActiveRecord::Migration
+  def change
+    add_column :sns_comments, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161110114514) do
+ActiveRecord::Schema.define(version: 20161110160609) do
 
   create_table "families", force: :cascade do |t|
     t.string   "name"
@@ -66,6 +66,19 @@ ActiveRecord::Schema.define(version: 20161110114514) do
   add_index "family_relationships", ["follow_id", "follower_id"], name: "index_family_relationships_on_follow_id_and_follower_id", unique: true
   add_index "family_relationships", ["follow_id"], name: "index_family_relationships_on_follow_id"
   add_index "family_relationships", ["follower_id"], name: "index_family_relationships_on_follower_id"
+
+  create_table "sns_comments", force: :cascade do |t|
+    t.integer  "family_id"
+    t.integer  "family_post_id"
+    t.integer  "user_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "sns_comments", ["family_id", "family_post_id", "user_id"], name: "index_sns_comments_on_family_id_and_family_post_id_and_user_id", unique: true
+  add_index "sns_comments", ["family_id"], name: "index_sns_comments_on_family_id"
+  add_index "sns_comments", ["family_post_id"], name: "index_sns_comments_on_family_post_id"
+  add_index "sns_comments", ["user_id"], name: "index_sns_comments_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "",       null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161110160609) do
+ActiveRecord::Schema.define(version: 20161111010142) do
 
   create_table "families", force: :cascade do |t|
     t.string   "name"
@@ -73,9 +73,10 @@ ActiveRecord::Schema.define(version: 20161110160609) do
     t.integer  "user_id"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+    t.text     "content"
   end
 
-  add_index "sns_comments", ["family_id", "family_post_id", "user_id"], name: "index_sns_comments_on_family_id_and_family_post_id_and_user_id", unique: true
+  add_index "sns_comments", ["family_id", "family_post_id", "user_id"], name: "index_sns_comments_on_family_id_and_family_post_id_and_user_id"
   add_index "sns_comments", ["family_id"], name: "index_sns_comments_on_family_id"
   add_index "sns_comments", ["family_post_id"], name: "index_sns_comments_on_family_post_id"
   add_index "sns_comments", ["user_id"], name: "index_sns_comments_on_user_id"

--- a/test/controllers/sns_comments_controller_test.rb
+++ b/test/controllers/sns_comments_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class SnsCommentsControllerTest < ActionController::TestCase
+  test "should get create" do
+    get :create
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get :destroy
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/sns_comments.yml
+++ b/test/fixtures/sns_comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  family_id: 
+  family_post_id: 
+  user_id: 
+
+two:
+  family_id: 
+  family_post_id: 
+  user_id: 

--- a/test/models/sns_comment_test.rb
+++ b/test/models/sns_comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SnsCommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#2 #33
family_postに対してコメントをつけられるようにします。
コメントはtwitterのようにツイート形式ではなく、コメントはあくまでコメントとして実装しました。
つまり、コメントのコメントまではできない形式です。