### PR TITLE
投稿の公開設定と、タイムライン表示の対応

### DIFF
--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -66,7 +66,7 @@ class FamiliesController < ApplicationController
     my_family = current_family
     @family_post = my_family.family_posts.build
     @sns_comment = my_family.sns_comments.build(user_id: current_user.id, family_post_id: 1)
-    @family_posts = my_family.family_posts.order(created_at: :desc).page(params[:page])
+    @family_posts = my_family.all_posts.order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -65,7 +65,8 @@ class FamiliesController < ApplicationController
   def timeline
     my_family = current_family
     @family_post = my_family.family_posts.build
-    @sns_comment = my_family.sns_comments.build(user_id: current_user.id, family_post_id: 1)
+    @sns_comment = my_family.sns_comments.build(user_id: current_user.id)
+    logger.debug("sns_comment   : #{@sns_comment}")
     @family_posts = my_family.all_posts.order(created_at: :desc).page(params[:page])
   end
 

--- a/app/controllers/family_posts_controller.rb
+++ b/app/controllers/family_posts_controller.rb
@@ -24,6 +24,6 @@ class FamilyPostsController < ApplicationController
 
   private
   def family_post_params
-    params.require(:family_post).permit(:family_id, :content, :stars_count, :images => [])
+    params.require(:family_post).permit(:family_id, :content, :stars_count, :friend_open, :general_open, :images => [])
   end
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -14,6 +14,8 @@ class Family < ActiveRecord::Base
                                 dependent: :destroy
   has_many :follower_families, through: :follower_relationships, source: :follow
 
+  has_many :family_posts, dependent: :destroy
+
   def follow(another_family)
     following_relationships.find_or_create_by(follower_id: another_family.id)
   end
@@ -31,7 +33,37 @@ class Family < ActiveRecord::Base
     following?(another_family) && another_family.following?(self)
   end
 
-  has_many :family_posts, dependent: :destroy
+  # def friend_families
+  #   followers = follower_families
+  #   friends = []
+  #   following_families.each do |follow|
+  #     if followers.include?(follow)
+  #       friends.push(follow)
+  #     end
+  #   end
+  #   logger.debug(friends)
+  #   friends
+  # end
+
+  def my_and_friend_families_posts
+    followers = follower_families
+    my_and_friends_posts = family_posts
+    following_families.each do |follow|
+      if followers.include?(follow)
+        my_and_friends_posts.push(follow.family_posts)
+      end
+    end
+    my_and_friends_posts
+  end
+
+  def all_posts
+    all_posts = family_posts
+    following_families.each do |f|
+      all_posts.push(f.family_posts)
+    end
+    all_posts
+  end
+
 
   has_many :family_post_stars, class_name: FamilyPostStar, foreign_key: 'family_id', dependent: :destroy
   has_many :stared_family_posts, through: :family_post_stars, source: :family_post

--- a/app/views/families/timeline.html.erb
+++ b/app/views/families/timeline.html.erb
@@ -16,8 +16,6 @@
         <!--<li id="generalSelectBtn">一般</li>-->
       <!--</ul>-->
     <!--</nav>-->
-    <%= logger.debug("aaaaa : #{current_family.family_posts}") %>
-
 
             <div id="friendOrGeneralContents">
       <h2>Friend</h2>

--- a/app/views/families/timeline.html.erb
+++ b/app/views/families/timeline.html.erb
@@ -16,21 +16,23 @@
         <!--<li id="generalSelectBtn">一般</li>-->
       <!--</ul>-->
     <!--</nav>-->
+    <%= logger.debug("aaaaa : #{current_family.family_posts}") %>
 
-    <div id="friendOrGeneralContents">
+
+            <div id="friendOrGeneralContents">
       <h2>Friend</h2>
-      <div id="friendContents">
+      <div id="familyPostsView">
         <% if @family_posts %>
-
-            <div id="familyPostsView">
-              <% @family_posts.each do |p| %>
-                  <div class="familyPost">
-                    <%= render 'family_posts/family_posts', family_post: p %>
-                  </div>
-              <% end %>
-            </div>
+            <% @family_posts.each do |f_p| %>
+                <div class="familyPost">
+                  <% if f_p.general_open || (f_p.friend_open && current_family.has_family_relationship?(f_p.family)) || current_family == f_p.family %>
+                    <%= render 'family_posts/family_posts', family_post: f_p %>
+                  <% end %>
+                </div>
+            <% end %>
             <%= paginate @family_posts %>
-        <% end %>
+
+      <% end %>
       </div>
 
       <div id="generalContents">

--- a/app/views/shared/_family_post_form.html.erb
+++ b/app/views/shared/_family_post_form.html.erb
@@ -8,6 +8,14 @@
       <%= f.file_field :images, :name => 'images[]', multiple: true %>
     </div>
     <div class="field">
+      <%= f.label :friend_open %><br>
+      <%= f.check_box :friend_open %>
+    </div>
+    <div class="field">
+      <%= f.label :general_open %><br>
+      <%= f.check_box :general_open %>
+    </div>
+    <div class="field">
       <%= f.hidden_field :family_id, value: current_family.id %>
     </div>
     <%= f.submit "Post", class: "btn btn-primary" %>

--- a/db/migrate/20161111063056_add_open_to_family_post.rb
+++ b/db/migrate/20161111063056_add_open_to_family_post.rb
@@ -1,0 +1,6 @@
+class AddOpenToFamilyPost < ActiveRecord::Migration
+  def change
+    add_column :family_posts, :friend_open, :boolean, default: false
+    add_column :family_posts, :general_open, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161111010142) do
+ActiveRecord::Schema.define(version: 20161111063056) do
 
   create_table "families", force: :cascade do |t|
     t.string   "name"
@@ -48,9 +48,11 @@ ActiveRecord::Schema.define(version: 20161111010142) do
   create_table "family_posts", force: :cascade do |t|
     t.integer  "family_id"
     t.text     "content"
-    t.integer  "stars_count", default: 0
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "stars_count",  default: 0
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.boolean  "friend_open",  default: false
+    t.boolean  "general_open", default: false
   end
 
   add_index "family_posts", ["family_id", "created_at"], name: "index_family_posts_on_family_id_and_created_at"


### PR DESCRIPTION
#2 #27 

- family_postモデルにfriend_open:booleanカラムと、gerenal_open:booleanカラムを作成。
- family.rbにall_postsメソッドを追加して、自分の投稿と、followしている家族のfamily_postを全て取得できるようにした
- コントローラで降順に並び替えてkaminariでページング
- タイムラインではリレーション関係を確認して表示/非表示判定